### PR TITLE
Made regex_flags optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,10 +8,6 @@ try {
     core.setFailed('regex_pattern input is required');
     return;
   }
-  if (!regexFlags) {
-    core.setFailed('regex_flags input is required');
-    return;
-  }
   if (!searchString) {
     core.setFailed('search_string input is required');
     return;


### PR DESCRIPTION
Remove the check that fails the task if regex_flags is missing or blank, as it has a fallback to use an empty string anyway.
Closes #6